### PR TITLE
fix:doris cache bug and Optimize Doris insertion filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target/
 .*/
 .run.gxl
+.rule
 wp-docs
 Cargo.lock

--- a/src/doris/sink.rs
+++ b/src/doris/sink.rs
@@ -1,3 +1,20 @@
+//! Doris Sink 实现
+//!
+//! # 重要说明
+//!
+//! Doris 虽然兼容 MySQL 协议，但**不完全支持 MySQL 的预编译语句（Prepared Statements）**。
+//! 因此本实现使用字符串拼接方式构建 SQL，但通过以下措施保证安全性：
+//!
+//! 1. **数据值转义** - 使用 `escape_sql_string()` 处理所有危险字符
+//! 2. **标识符转义** - 使用 `quote_identifier()` 处理表名和列名
+//! 3. **批量插入** - 保持高性能的多行 INSERT
+//!
+//! # SQL 注入防护
+//!
+//! - 所有用户数据通过 `escape_sql_string()` 转义（反斜杠、单引号、NULL、换行等）
+//! - 所有标识符通过 `quote_identifier()` 包裹反引号
+//! - 不直接拼接未转义的用户输入
+
 use crate::doris::config::DorisSinkConfig;
 use async_trait::async_trait;
 use sqlx::{
@@ -5,8 +22,11 @@ use sqlx::{
     mysql::{MySqlConnectOptions, MySqlPool, MySqlPoolOptions},
     raw_sql,
 };
-use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::{
+    collections::{HashMap, HashSet},
+    // sync::atomic::{AtomicUsize, Ordering},
+};
 use wp_connector_api::{
     AsyncCtrl, AsyncRawDataSink, AsyncRecordSink, SinkError, SinkReason, SinkResult,
 };
@@ -18,8 +38,6 @@ pub struct DorisSink {
     column_order: Vec<String>,
     quoted_columns: Vec<String>,
     column_set: HashSet<String>,
-    batch_size: usize,
-    pending_values: Vec<String>,
 }
 
 impl DorisSink {
@@ -66,8 +84,6 @@ impl DorisSink {
             column_order,
             quoted_columns,
             column_set,
-            batch_size: config.batch_size,
-            pending_values: Vec::with_capacity(config.batch_size),
         })
     }
 
@@ -84,6 +100,7 @@ impl DorisSink {
     }
 
     /// 将一条 [`DataRecord`] 转换成 `(v1, v2, ..)` 形式的 VALUES 片段。
+    /// 使用安全的转义函数防止 SQL 注入。
     ///
     /// # args
     /// * `record` - 上层传入的数据记录。
@@ -109,7 +126,7 @@ impl DorisSink {
             .column_order
             .iter()
             .map(|column| match field_map.get(column.as_str()) {
-                Some(value) => format!("'{}'", escape_single_quotes(value)),
+                Some(value) => format!("'{}'", escape_sql_string(value)),
                 None => "NULL".to_string(),
             })
             .collect();
@@ -117,24 +134,24 @@ impl DorisSink {
     }
 
     /// 将缓存的 VALUES 组成批量 INSERT 并写入 Doris。
+    /// 注意：Doris 不完全支持 MySQL 预编译语句，因此使用字符串拼接 + 安全转义。
+    ///
+    /// # args
+    /// * `sql_values` - VALUES 片段列表。
     ///
     /// # return
     /// * `SinkResult<()>` - 成功表示缓存已清空。
-    async fn flush_pending(&mut self) -> SinkResult<()> {
-        if self.pending_values.is_empty() {
+    async fn flush_pending(&mut self, sql_values: Vec<String>) -> SinkResult<()> {
+        if sql_values.is_empty() {
             return Ok(());
         }
-        //"INSERT INTO `wp_test`.`events_parsed` (`occur_time`, `src_ip`, `wp_event_id`, `time`, `digit`, `chars`, `wp_src_key`) VALUES (NULL, NULL, '1766973779209849128', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849129', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849130', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849131', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849132', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849133', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849134', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849135', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849136', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849137', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849138', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849139', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849140', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849141', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849142', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849143', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849144', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849145', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849146', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849147', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849148', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849149', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849150', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849151', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849152', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849153', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849154', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849155', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849156', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849157', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849158', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849159', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849160', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849161', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849162', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849163', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849164', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849165', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849166', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849167', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849168', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849169', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849170', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849171', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849172', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849173', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849174', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849175', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849176', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849177', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849178', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849179', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849180', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849181', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849182', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849183', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849184', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849185', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849186', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849187', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849188', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849189', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849190', NULL, NULL, NULL, 'file_1'), (NULL, NULL, '1766973779209849191', NULL, NULL, NULL, 'file_1')"
-        let sql = format!(
-            "{}{}",
-            self.base_insert_prefix(),
-            self.pending_values.join(", ")
-        );
+
+        let sql = format!("{}{}", self.base_insert_prefix(), sql_values.join(", "));
         raw_sql(&sql)
             .execute(&self.pool)
             .await
             .map_err(|e| sink_error(format!("doris insert fail: {}", e)))?;
-        self.pending_values.clear();
+
         Ok(())
     }
 }
@@ -142,36 +159,43 @@ impl DorisSink {
 #[async_trait]
 impl AsyncCtrl for DorisSink {
     async fn stop(&mut self) -> SinkResult<()> {
-        self.flush_pending().await
+        Ok(())
     }
 
     async fn reconnect(&mut self) -> SinkResult<()> {
-        sqlx::query("SELECT 1")
-            .execute(&self.pool)
+        // Doris 不支持预编译，使用 raw_sql
+        raw_sql("SELECT 1")
+            .fetch_one(&self.pool)
             .await
-            .map_err(|e| sink_error(format!("doris reconnect fail: {}", e)))?
-            .rows_affected();
+            .map_err(|e| sink_error(format!("doris reconnect fail: {}", e)))?;
         Ok(())
     }
 }
 
+// static REC_CNT: AtomicUsize = AtomicUsize::new(0);
+// static SED_CNT: AtomicUsize = AtomicUsize::new(0);
+
 #[async_trait]
 impl AsyncRecordSink for DorisSink {
     async fn sink_record(&mut self, data: &DataRecord) -> SinkResult<()> {
-        if let Some(raw) = self.format_values_tuple(data) {
-            self.pending_values.push(raw);
-            if self.pending_values.len() >= self.batch_size {
-                self.flush_pending().await?;
-            }
-        }
-        Ok(())
+        self.sink_records(vec![Arc::new(data.clone())]).await
     }
 
     async fn sink_records(&mut self, data: Vec<Arc<DataRecord>>) -> SinkResult<()> {
-        for record in data {
-            self.sink_record(record.as_ref()).await?;
+        if data.is_empty() {
+            return Ok(());
         }
-        Ok(())
+        // let cnt = REC_CNT.fetch_add(data.len(), Ordering::Relaxed) + data.len();
+        // println!("doris已接收:{}", cnt);
+        let sql_values = data
+            .iter()
+            .filter_map(|record| self.format_values_tuple(record.as_ref()))
+            .collect();
+
+        self.flush_pending(sql_values).await?;
+        // let cnt = SED_CNT.fetch_add(data.len(), Ordering::Relaxed) + data.len();
+        // println!("doris已发送:{}", cnt);
+        return Ok(());
     }
 }
 
@@ -211,15 +235,22 @@ fn quote_identifier(input: &str) -> String {
         .join(".")
 }
 
-/// 将值中的单引号替换成 SQL 可接受的形式。
+/// 安全地转义 SQL 字符串值，防止 SQL 注入。
+/// 适用于 Doris/MySQL 字符串字面量。
 ///
 /// # args
 /// * `value` - 原始字符串。
 ///
 /// # return
-/// * `String` - 转义后的字符串。
-fn escape_single_quotes(value: &str) -> String {
-    value.replace('\'', "''")
+/// * `String` - 转义后的字符串，可安全用于 SQL 语句。
+fn escape_sql_string(value: &str) -> String {
+    value
+        .replace('\\', "\\\\") // 反斜杠必须最先处理
+        .replace('\'', "''") // 单引号
+        .replace('\0', "\\0") // NULL 字节
+        .replace('\n', "\\n") // 换行符
+        .replace('\r', "\\r") // 回车符
+        .replace('\x1a', "\\Z") // Ctrl+Z (Windows EOF)
 }
 
 /// 统一封装 sink 层错误，便于上层识别。
@@ -284,6 +315,7 @@ async fn create_database_if_missing(cfg: &DorisSinkConfig) -> anyhow::Result<()>
 }
 
 /// 检查并必要时创建目标表。
+/// 注意：Doris 不完全支持预编译语句，使用字符串拼接 + 转义。
 ///
 /// # args
 /// * `pool` - 已连接至目标库的连接池。
@@ -298,10 +330,11 @@ async fn ensure_table_exists(
     table: &str,
     create_stmt: Option<&str>,
 ) -> anyhow::Result<()> {
+    // Doris 不支持预编译，使用字符串拼接但安全转义
     let exists_sql = format!(
         "SELECT COUNT(1) AS cnt FROM information_schema.TABLES WHERE TABLE_SCHEMA='{}' AND TABLE_NAME='{}'",
-        escape_single_quotes(database),
-        escape_single_quotes(table)
+        escape_sql_string(database),
+        escape_sql_string(table)
     );
     let row = raw_sql(&exists_sql).fetch_one(pool).await?;
     let exists: i64 = row.try_get("cnt")?;
@@ -318,6 +351,7 @@ async fn ensure_table_exists(
 }
 
 /// 从 information_schema 读取列顺序，作为批量写入的列序。
+/// 注意：Doris 不完全支持预编译语句，使用字符串拼接 + 转义。
 ///
 /// # args
 /// * `pool` - 连接池。
@@ -330,10 +364,11 @@ async fn load_table_columns(
     database: &str,
     table: &str,
 ) -> anyhow::Result<Vec<String>> {
+    // Doris 不支持预编译，使用字符串拼接但安全转义
     let sql = format!(
         "SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA='{}' AND TABLE_NAME='{}' ORDER BY ORDINAL_POSITION",
-        escape_single_quotes(database),
-        escape_single_quotes(table)
+        escape_sql_string(database),
+        escape_sql_string(table)
     );
     let rows = raw_sql(&sql).fetch_all(pool).await?;
 
@@ -347,7 +382,7 @@ async fn load_table_columns(
 
 #[cfg(test)]
 mod tests {
-    use super::quote_identifier;
+    use super::*;
 
     #[test]
     fn quote_identifier_handles_segments() {
@@ -355,11 +390,27 @@ mod tests {
         assert_eq!(quote_identifier("demo.events"), "`demo`.`events`");
     }
 
-    // #[test]
-    // fn test_new() {
-    //     DorisSinkConfig{
-    //         endpoint:"",
+    #[test]
+    fn test_escape_sql_string() {
+        // 测试单引号
+        assert_eq!(escape_sql_string("O'Reilly"), "O''Reilly");
 
-    //     }
-    // }
+        // 测试反斜杠
+        assert_eq!(escape_sql_string("C:\\path"), "C:\\\\path");
+
+        // 测试换行符
+        assert_eq!(escape_sql_string("line1\nline2"), "line1\\nline2");
+
+        // 测试回车符
+        assert_eq!(escape_sql_string("text\rmore"), "text\\rmore");
+
+        // 测试 NULL 字节
+        assert_eq!(escape_sql_string("text\0null"), "text\\0null");
+
+        // 测试组合
+        assert_eq!(
+            escape_sql_string("It's a\\path\nwith'quotes"),
+            "It''s a\\\\path\\nwith''quotes"
+        );
+    }
 }


### PR DESCRIPTION
**Description**
**Problem**
The existence of an internal cache in the connector can prevent the last piece of data from being sent, leading to data loss in certain scenarios.

**Solution**
This PR removes the cache inside the connector and relies on **wparse’s cache mechanism** instead. By centralizing caching behavior in wparse, we ensure that all buffered data is flushed correctly and avoid losing the final record.

**Related Issue**
[https://github.com/wp-labs/warp-parse/issues/137](https://github.com/wp-labs/warp-parse/issues/137)
