### PR TITLE
doris自动识别表名

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@ target/
 .DS_Store
 _gal/.report
 Cargo.lock
+
+.idea
+.kiro
+.*
+.run
+temp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,8 @@ base64 = { workspace = true, optional = true }
 sysinfo = { version = "0.38", default-features = false, features = ["system"], optional = true }
 
 [dev-dependencies]
-wp-connector-test-utils = { git = "https://github.com/wp-labs/wp-connector-test-utils.git", tag = "v0.2.1"}
+wp-connector-test-utils = { git = "https://github.com/wp-labs/wp-connector-test-utils.git", tag = "v0.2.2"}
+# wp-connector-test-utils = { path = "../wp-connector-test-utils" }
 anyhow = { workspace = true }
 env_logger = { workspace = true }
 httpmock = "0.8"

--- a/src/doris/sink.rs
+++ b/src/doris/sink.rs
@@ -37,7 +37,10 @@ static INSTANCE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub struct DorisSink {
     client: Client,
-    url: String, // 预先构建的完整 URL
+    endpoint: String,
+    database: String,
+    table_template: String,
+    template_fields: Vec<String>,
     user: String,
     password: String,
     max_retries: i32,
@@ -72,6 +75,11 @@ enum LoadOutcome {
     Error(String),
 }
 
+struct DorisTableBatch {
+    table_name: String,
+    payload: Vec<u8>,
+}
+
 impl DorisSink {
     /// 构建 Doris Sink，使用 Stream Load API。
     ///
@@ -87,18 +95,17 @@ impl DorisSink {
             .build()
             .source_raw_err(SinkReason::Sink, "doris client build")?;
 
-        // 预先构建完整的 Stream Load URL
-        let url = format!(
-            "{}/api/{}/{}/_stream_load",
-            config.endpoint, config.database, config.table
-        );
+        let template_fields = parse_template_fields(&config.table)?;
 
         // 从全局原子变量获取递增的实例 ID
         let instance_id = INSTANCE_COUNTER.fetch_add(1, Ordering::SeqCst);
 
         Ok(Self {
             client,
-            url,
+            endpoint: config.endpoint,
+            database: config.database,
+            table_template: config.table,
+            template_fields,
             user: config.user,
             password: config.password,
             max_retries: config.max_retries,
@@ -125,29 +132,62 @@ impl DorisSink {
         )
     }
 
-    /// 将 DataRecord 转换为 JSON 对象。
-    ///
-    /// # Arguments
-    /// * `record` - 数据记录
-    ///
-    /// # Returns
-    /// 将批量记录转换为 NDJSON 格式（每行一个 JSON 对象）。
-    ///
-    /// # Arguments
-    /// * `records` - 数据记录列表
-    ///
-    /// # Returns
-    /// * `SinkResult<Bytes>` - NDJSON 字节流
-    fn records_to_ndjson(&self, records: &[Arc<DataRecord>]) -> SinkResult<Bytes> {
-        let mut buffer = Vec::new();
+    fn write_record_json_line(&self, buffer: &mut Vec<u8>, record: &DataRecord) -> SinkResult<()> {
+        serde_json::to_writer(&mut *buffer, &JsonRecord(record, &self.template_fields))
+            .source_raw_err(SinkReason::Sink, "json serialization failed")?;
+        buffer.push(b'\n');
+        Ok(())
+    }
 
-        for record in records {
-            serde_json::to_writer(&mut buffer, &JsonRecord(record.as_ref()))
-                .source_raw_err(SinkReason::Sink, "json serialization failed")?;
-            buffer.push(b'\n');
+    fn build_table_name(&self, record: &DataRecord) -> SinkResult<String> {
+        let mut table_name = self.table_template.clone();
+
+        for field_name in &self.template_fields {
+            let field = record
+                .items
+                .iter()
+                .find(|field| field.get_name() == field_name)
+                .ok_or_else(|| {
+                    sink_error(format!(
+                        "doris dynamic table field '{}' is missing in template '{}'",
+                        field_name, self.table_template
+                    ))
+                })?;
+
+            let field_value = match field.get_value() {
+                Value::Chars(value) => value.as_str(),
+                _ => {
+                    return Err(sink_error(format!(
+                        "doris dynamic table field '{}' must be a string",
+                        field_name
+                    )));
+                }
+            };
+
+            table_name = table_name.replace(&format!("#{{{}}}", field_name), field_value);
         }
 
-        Ok(Bytes::from(buffer))
+        Ok(table_name)
+    }
+
+    fn records_to_table_batches(
+        &self,
+        records: Vec<Arc<DataRecord>>,
+    ) -> SinkResult<Vec<DorisTableBatch>> {
+        let mut batches: HashMap<String, DorisTableBatch> = HashMap::new();
+
+        for record in records {
+            let table_name = self.build_table_name(record.as_ref())?;
+            let batch = batches
+                .entry(table_name.clone())
+                .or_insert_with(|| DorisTableBatch {
+                    table_name,
+                    payload: Vec::new(),
+                });
+            self.write_record_json_line(&mut batch.payload, record.as_ref())?;
+        }
+
+        Ok(batches.into_values().collect())
     }
 
     /// 执行 Stream Load 请求。
@@ -160,15 +200,21 @@ impl DorisSink {
     /// # Returns
     ///
     /// * `SinkResult<()>` - 成功或错误
-    async fn stream_load(&self, label: &str, data: Bytes) -> SinkResult<()> {
+    async fn stream_load(&self, batch: DorisTableBatch) -> SinkResult<()> {
+        let data = Bytes::from(batch.payload);
+        let label = self.generate_label(&data);
+        let url = format!(
+            "{}/api/{}/{}/_stream_load",
+            self.endpoint, self.database, batch.table_name
+        );
         let mut retries = 0i32;
 
         loop {
             let mut request = self
                 .client
-                .put(&self.url)
+                .put(&url)
                 .basic_auth(&self.user, Some(&self.password))
-                .header("label", label)
+                .header("label", label.as_str())
                 .header("format", "json")
                 .header("read_json_by_line", "true")
                 .header("Expect", "100-continue")
@@ -189,7 +235,12 @@ impl DorisSink {
 
                     match Self::classify_load_response(status, &body) {
                         LoadOutcome::Success => return Ok(()),
-                        LoadOutcome::Error(message) => return Err(sink_error(message)),
+                        LoadOutcome::Error(message) => {
+                            return Err(sink_error(format!(
+                                "stream load failed for table {}: {}",
+                                batch.table_name, message
+                            )));
+                        }
                         LoadOutcome::Retry(reason) => {
                             let retry_limit = if self.max_retries < 0 {
                                 "unlimited".to_string()
@@ -199,13 +250,14 @@ impl DorisSink {
 
                             if self.max_retries >= 0 && retries >= self.max_retries {
                                 return Err(sink_error(format!(
-                                    "max retries ({}) exceeded: {}",
-                                    self.max_retries, reason
+                                    "max retries ({}) exceeded for table {}: {}",
+                                    self.max_retries, batch.table_name, reason
                                 )));
                             }
 
                             log::warn!(
-                                "stream load retry needed: label={}, reason={}, retry={}/{}",
+                                "stream load retry needed: table={}, label={}, reason={}, retry={}/{}",
+                                batch.table_name,
                                 label,
                                 reason,
                                 retries + 1,
@@ -217,8 +269,8 @@ impl DorisSink {
                 Err(e) => {
                     if self.max_retries >= 0 && retries >= self.max_retries {
                         return Err(sink_error(format!(
-                            "max retries ({}) exceeded: request failed: {}",
-                            self.max_retries, e
+                            "max retries ({}) exceeded for table {}: request failed: {}",
+                            self.max_retries, batch.table_name, e
                         )));
                     }
 
@@ -228,7 +280,8 @@ impl DorisSink {
                         self.max_retries.to_string()
                     };
                     log::warn!(
-                        "request failed: {}, retry={}/{}",
+                        "request failed: table={}, error={}, retry={}/{}",
+                        batch.table_name,
                         e,
                         retries + 1,
                         retry_limit
@@ -240,15 +293,6 @@ impl DorisSink {
             let backoff_ms = 1000 * 2_u64.pow(retries.min(10) as u32);
             tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
         }
-    }
-
-    /// 刷新缓冲区，将所有缓存的记录发送到 Doris。
-    ///
-    /// # Returns
-    /// * `SinkResult<()>` - 成功或错误
-    async fn flush_buffer(&mut self) -> SinkResult<()> {
-        // No-op: buffering is disabled, records are sent immediately
-        Ok(())
     }
 
     fn ensure_running(&self) -> SinkResult<()> {
@@ -340,9 +384,6 @@ impl AsyncCtrl for DorisSink {
         if self.stopped {
             return Ok(());
         }
-
-        // 停止前刷新缓冲区，确保没有数据丢失
-        self.flush_buffer().await?;
         self.stopped = true;
         Ok(())
     }
@@ -372,10 +413,9 @@ impl AsyncRecordSink for DorisSink {
         // 开始统计
         self.time_stats.start_stat(data.len() as u64);
 
-        // 生成label
-        let ndjson = self.records_to_ndjson(&data)?;
-        let label = self.generate_label(&ndjson);
-        self.stream_load(&label, ndjson).await?;
+        for batch in self.records_to_table_batches(data)? {
+            self.stream_load(batch).await?;
+        }
 
         // 结束统计
         self.time_stats.end_stat();
@@ -414,6 +454,36 @@ fn sink_error(msg: impl Into<String>) -> SinkError {
     SinkReason::sink(msg)
 }
 
+fn parse_template_fields(template: &str) -> SinkResult<Vec<String>> {
+    let mut fields = Vec::new();
+    let mut rest = template;
+
+    while let Some(start) = rest.find("#{") {
+        let after_start = &rest[start + 2..];
+        let Some(end) = after_start.find('}') else {
+            return Err(sink_error(format!(
+                "invalid doris table template '{}': missing closing '}}'",
+                template
+            )));
+        };
+
+        let field = &after_start[..end];
+        if field.is_empty() {
+            return Err(sink_error(format!(
+                "invalid doris table template '{}': empty placeholder",
+                template
+            )));
+        }
+
+        if !fields.iter().any(|existing| existing == field) {
+            fields.push(field.to_string());
+        }
+        rest = &after_start[end + 1..];
+    }
+
+    Ok(fields)
+}
+
 fn fingerprint_bytes(bytes: &[u8]) -> (u64, u64) {
     const OFFSET_A: u64 = 0xcbf29ce484222325;
     const OFFSET_B: u64 = 0x84222325cbf29ce4;
@@ -434,7 +504,7 @@ fn fingerprint_bytes(bytes: &[u8]) -> (u64, u64) {
     (hash_a, hash_b)
 }
 
-struct JsonRecord<'a>(&'a DataRecord);
+struct JsonRecord<'a>(&'a DataRecord, &'a [String]);
 
 impl Serialize for JsonRecord<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -445,12 +515,17 @@ impl Serialize for JsonRecord<'_> {
             .0
             .items
             .iter()
-            .filter(|field| *field.get_meta() != DataType::Ignore)
+            .filter(|field| {
+                *field.get_meta() != DataType::Ignore
+                    && !self.1.iter().any(|name| name == field.get_name())
+            })
             .count();
         let mut map = serializer.serialize_map(Some(field_count))?;
 
         for field in &self.0.items {
-            if *field.get_meta() == DataType::Ignore {
+            if *field.get_meta() == DataType::Ignore
+                || self.1.iter().any(|name| name == field.get_name())
+            {
                 continue;
             }
 
@@ -541,6 +616,19 @@ mod tests {
         )
     }
 
+    fn test_config_with_table(table: &str) -> DorisSinkConfig {
+        DorisSinkConfig::new(
+            "http://localhost:8040".into(),
+            "demo".into(),
+            table.into(),
+            "root".into(),
+            "".into(),
+            Some(1),
+            Some(0),
+            None,
+        )
+    }
+
     async fn create_mock_sink(server: &MockServer, max_retries: i32) -> DorisSink {
         let mut headers = HashMap::new();
         headers.insert("strict_mode".into(), "true".into());
@@ -562,6 +650,15 @@ mod tests {
     fn sample_record() -> DataRecord {
         let mut record = DataRecord::default();
         record.append(DataField::from_digit("id", 1));
+        record.append(DataField::from_chars("name", "alice"));
+        record
+    }
+
+    fn sample_record_with_route(id: i64, tenant: &str, day: &str) -> DataRecord {
+        let mut record = DataRecord::default();
+        record.append(DataField::from_digit("id", id));
+        record.append(DataField::from_chars("tenant", tenant));
+        record.append(DataField::from_chars("day", day));
         record.append(DataField::from_chars("name", "alice"));
         record
     }
@@ -664,7 +761,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn record_to_json_preserves_value_types() {
+    async fn write_record_json_line_preserves_value_types() {
         let sink = DorisSink::new(test_config()).await.unwrap();
         let mut record = DataRecord::default();
         record.append(DataField::from_chars("zip_code", "00123"));
@@ -682,13 +779,32 @@ mod tests {
         );
         record.append(DataField::new(DataType::Obj, "meta", Value::Obj(nested)));
 
-        let encoded = sink.records_to_ndjson(&[Arc::new(record)]).unwrap();
-        let json: serde_json::Value = serde_json::from_slice(encoded.as_ref()).unwrap();
+        let mut encoded = Vec::new();
+        sink.write_record_json_line(&mut encoded, &record).unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&encoded).unwrap();
 
         assert_eq!(json["zip_code"], serde_json::Value::String("00123".into()));
         assert_eq!(json["enabled"], serde_json::Value::Bool(true));
         assert_eq!(json["meta"]["count"], serde_json::Value::Number(7.into()));
         assert!(json["meta"].get("ignored").is_none());
+        assert_eq!(encoded.last(), Some(&b'\n'));
+    }
+
+    #[tokio::test]
+    async fn write_record_json_line_removes_template_fields() {
+        let sink = DorisSink::new(test_config_with_table("events_#{tenant}_#{day}"))
+            .await
+            .unwrap();
+        let record = sample_record_with_route(1, "acme", "20260527");
+
+        let mut encoded = Vec::new();
+        sink.write_record_json_line(&mut encoded, &record).unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&encoded).unwrap();
+
+        assert_eq!(json["id"], serde_json::Value::Number(1.into()));
+        assert_eq!(json["name"], serde_json::Value::String("alice".into()));
+        assert!(json.get("tenant").is_none());
+        assert!(json.get("day").is_none());
     }
 
     #[tokio::test]
@@ -696,12 +812,174 @@ mod tests {
         let sink = DorisSink::new(test_config()).await.unwrap();
         let record = sample_record();
 
-        let payload = sink.records_to_ndjson(&[Arc::new(record.clone())]).unwrap();
+        let mut payload = Vec::new();
+        sink.write_record_json_line(&mut payload, &record).unwrap();
+        let payload = Bytes::from(payload);
         let label_a = sink.generate_label(&payload);
-        let payload_again = sink.records_to_ndjson(&[Arc::new(record)]).unwrap();
+
+        let mut payload_again = Vec::new();
+        sink.write_record_json_line(&mut payload_again, &record)
+            .unwrap();
+        let payload_again = Bytes::from(payload_again);
         let label_b = sink.generate_label(&payload_again);
 
         assert_eq!(label_a, label_b);
+    }
+
+    #[tokio::test]
+    async fn records_to_table_batches_groups_by_dynamic_table() {
+        let sink = DorisSink::new(test_config_with_table("events_#{tenant}_#{day}"))
+            .await
+            .unwrap();
+
+        let mut batches = sink
+            .records_to_table_batches(vec![
+                Arc::new(sample_record_with_route(1, "acme", "20260527")),
+                Arc::new(sample_record_with_route(2, "acme", "20260527")),
+                Arc::new(sample_record_with_route(3, "beta", "20260527")),
+            ])
+            .unwrap();
+        batches.sort_by(|left, right| left.table_name.cmp(&right.table_name));
+
+        assert_eq!(batches.len(), 2);
+        assert_eq!(batches[0].table_name, "events_acme_20260527");
+        assert_eq!(batches[1].table_name, "events_beta_20260527");
+
+        let acme_payload = String::from_utf8(batches[0].payload.clone()).unwrap();
+        assert_eq!(acme_payload.lines().count(), 2);
+        assert!(acme_payload.contains("\"id\":1"));
+        assert!(acme_payload.contains("\"id\":2"));
+        assert!(!acme_payload.contains("tenant"));
+        assert!(!acme_payload.contains("day"));
+
+        let beta_payload = String::from_utf8(batches[1].payload.clone()).unwrap();
+        assert_eq!(beta_payload.lines().count(), 1);
+        assert!(beta_payload.contains("\"id\":3"));
+        assert!(!beta_payload.contains("tenant"));
+        assert!(!beta_payload.contains("day"));
+    }
+
+    #[tokio::test]
+    async fn dynamic_table_groups_records_and_removes_template_fields() {
+        let server = MockServer::start_async().await;
+        let mut sink = DorisSink::new(DorisSinkConfig::new(
+            server.base_url(),
+            "demo".into(),
+            "events_#{tenant}_#{day}".into(),
+            "root".into(),
+            "".into(),
+            Some(5),
+            Some(0),
+            None,
+        ))
+        .await
+        .unwrap();
+
+        let tenant_a_mock = server
+            .mock_async(|when, then| {
+                when.method(PUT)
+                    .path("/api/demo/events_acme_20260527/_stream_load")
+                    .header("format", "json")
+                    .header("read_json_by_line", "true")
+                    .body_includes("\"id\":1")
+                    .body_includes("\"id\":2")
+                    .body_includes("\"name\":\"alice\"")
+                    .body_not("tenant")
+                    .body_not("day");
+                then.status(200).json_body_obj(&serde_json::json!({
+                    "Status": "Success",
+                    "NumberLoadedRows": 2,
+                    "NumberFilteredRows": 0
+                }));
+            })
+            .await;
+        let tenant_b_mock = server
+            .mock_async(|when, then| {
+                when.method(PUT)
+                    .path("/api/demo/events_beta_20260527/_stream_load")
+                    .header("format", "json")
+                    .header("read_json_by_line", "true")
+                    .body_includes("\"id\":3")
+                    .body_includes("\"name\":\"alice\"")
+                    .body_not("tenant")
+                    .body_not("day");
+                then.status(200).json_body_obj(&serde_json::json!({
+                    "Status": "Success",
+                    "NumberLoadedRows": 1,
+                    "NumberFilteredRows": 0
+                }));
+            })
+            .await;
+
+        sink.sink_records(vec![
+            Arc::new(sample_record_with_route(1, "acme", "20260527")),
+            Arc::new(sample_record_with_route(2, "acme", "20260527")),
+            Arc::new(sample_record_with_route(3, "beta", "20260527")),
+        ])
+        .await
+        .unwrap();
+
+        tenant_a_mock.assert_calls_async(1).await;
+        tenant_b_mock.assert_calls_async(1).await;
+    }
+
+    #[tokio::test]
+    async fn dynamic_table_accepts_repeated_placeholder() {
+        let sink = DorisSink::new(test_config_with_table("events_#{tenant}_#{tenant}"))
+            .await
+            .unwrap();
+        let record = sample_record_with_route(1, "acme", "20260527");
+
+        assert_eq!(sink.build_table_name(&record).unwrap(), "events_acme_acme");
+        assert_eq!(sink.template_fields, vec!["tenant"]);
+    }
+
+    #[tokio::test]
+    async fn dynamic_table_rejects_invalid_template() {
+        let err = match DorisSink::new(test_config_with_table("events_#{tenant")).await {
+            Ok(_) => panic!("invalid template should fail"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.reason(), &SinkReason::Sink);
+        assert!(
+            err.detail()
+                .as_deref()
+                .is_some_and(|m| m.contains("missing closing"))
+        );
+    }
+
+    #[tokio::test]
+    async fn dynamic_table_rejects_missing_field() {
+        let sink = DorisSink::new(test_config_with_table("events_#{tenant}"))
+            .await
+            .unwrap();
+        let err = sink.build_table_name(&sample_record()).unwrap_err();
+
+        assert_eq!(err.reason(), &SinkReason::Sink);
+        assert!(
+            err.detail()
+                .as_deref()
+                .is_some_and(|m| m.contains("is missing"))
+        );
+    }
+
+    #[tokio::test]
+    async fn dynamic_table_rejects_non_string_field() {
+        let sink = DorisSink::new(test_config_with_table("events_#{tenant}"))
+            .await
+            .unwrap();
+        let mut record = DataRecord::default();
+        record.append(DataField::from_digit("tenant", 1));
+
+        let err = sink.build_table_name(&record).unwrap_err();
+
+        assert_eq!(err.reason(), &SinkReason::Sink);
+        assert!(
+            err.detail()
+                .as_deref()
+                .is_some_and(|m| m.contains("must be a string"))
+        );
     }
 
     #[tokio::test]
@@ -709,7 +987,9 @@ mod tests {
         let server = MockServer::start_async().await;
         let mut sink = create_mock_sink(&server, 1).await;
         let record = sample_record();
-        let payload = sink.records_to_ndjson(&[Arc::new(record.clone())]).unwrap();
+        let mut payload = Vec::new();
+        sink.write_record_json_line(&mut payload, &record).unwrap();
+        let payload = Bytes::from(payload);
         let expected_label = sink.generate_label(&payload);
 
         let running_mock = server

--- a/tests/README.md
+++ b/tests/README.md
@@ -305,7 +305,7 @@ runtime.run(true).await?;
 cargo test --tests --features external_integration integration_tests:: -- --nocapture --ignored --test-threads=1
 
 # 全部 sink 性能测试
-cargo test --release --tests --features external_performance performance_tests:: -- --nocapture --ignored
+cargo test --release --release --tests --features external_performance performance_tests:: -- --nocapture --ignored
 
 # Kafka source 集成测试
 cargo test --package wp-connectors --test kafka_tests --features kafka,external_integration source_integration_tests::test_kafka_source_basic_integration -- --exact --nocapture --ignored
@@ -314,47 +314,47 @@ cargo test --package wp-connectors --test kafka_tests --features kafka,external_
 cargo test --package wp-connectors --test kafka_tests --features kafka,external_integration integration_tests::test_kafka_sink_full_integration -- --exact --nocapture --ignored
 
 # Kafka sink 性能测试
-cargo test --package wp-connectors --test kafka_tests --features kafka,external_performance performance_tests::test_kafka_sink_performance -- --exact --nocapture --ignored
+cargo test --release --package wp-connectors --test kafka_tests --features kafka,external_performance performance_tests::test_kafka_sink_performance -- --exact --nocapture --ignored
 
 # Doris sink 集成测试
 cargo test --package wp-connectors --test doris_tests integration_tests::test_doris_sink_full_integration --features doris,external_integration -- --exact --nocapture --ignored
 
 # Doris sink 性能测试
-cargo test --package wp-connectors --test doris_tests performance_tests::test_doris_sink_performance --features doris,external_performance -- --exact --nocapture --ignored
+cargo test --release --package wp-connectors --test doris_tests performance_tests::test_doris_sink_performance --features doris,external_performance -- --exact --nocapture --ignored
 
 # HTTP sink 集成测试
 cargo test --package wp-connectors --test http_tests --features http,external_integration integration_tests::test_http_sink_full_integration -- --exact --nocapture --ignored
 
 # HTTP sink 性能测试
-cargo test --package wp-connectors --test http_tests --features http,external_performance performance_tests::test_http_sink_performance -- --exact --nocapture --ignored
+cargo test --release --package wp-connectors --test http_tests --features http,external_performance performance_tests::test_http_sink_performance -- --exact --nocapture --ignored
 
 # ClickHouse sink 集成测试
 cargo test --package wp-connectors --test clickhouse_tests --features clickhouse,external_integration integration_tests::test_clickhouse_sink_full_integration -- --exact --nocapture --ignored
 
 # ClickHouse sink 性能测试
-cargo test --package wp-connectors --test clickhouse_tests --features clickhouse,external_performance performance_tests::test_clickhouse_sink_performance -- --exact --nocapture --ignored
+cargo test --release --package wp-connectors --test clickhouse_tests --features clickhouse,external_performance performance_tests::test_clickhouse_sink_performance -- --exact --nocapture --ignored
 
 # MySQL sink 集成测试
 cargo test --package wp-connectors --test mysql_tests --features mysql,external_integration integration_tests::test_mysql_sink_full_integration -- --exact --nocapture --ignored
 
 # MySQL sink 性能测试
-cargo test --package wp-connectors --test mysql_tests --features mysql,external_performance performance_tests::test_mysql_sink_performance -- --exact --nocapture --ignored
+cargo test --release --package wp-connectors --test mysql_tests --features mysql,external_performance performance_tests::test_mysql_sink_performance -- --exact --nocapture --ignored
 
 # Elasticsearch sink 集成测试
 cargo test --package wp-connectors --test elasticsearch_tests --features elasticsearch,external_integration integration_tests::test_elasticsearch_sink_full_integration -- --exact --nocapture --ignored
 
 # Elasticsearch sink 性能测试
-cargo test --package wp-connectors --test elasticsearch_tests --features elasticsearch,external_performance performance_tests::test_elasticsearch_sink_performance -- --exact --nocapture --ignored
+cargo test --release --package wp-connectors --test elasticsearch_tests --features elasticsearch,external_performance performance_tests::test_elasticsearch_sink_performance -- --exact --nocapture --ignored
 
 # PostgreSQL sink 集成测试
 cargo test --package wp-connectors --test postgresql_tests --features postgres,external_integration integration_tests::test_postgresql_sink_full_integration -- --exact --nocapture --ignored
 
 # PostgreSQL sink 性能测试
-cargo test --package wp-connectors --test postgresql_tests --features postgres,external_performance performance_tests::test_postgresql_sink_performance -- --exact --nocapture --ignored
+cargo test --release --package wp-connectors --test postgresql_tests --features postgres,external_performance performance_tests::test_postgresql_sink_performance -- --exact --nocapture --ignored
 
 # VictoriaLogs sink 集成测试
 cargo test --package wp-connectors --test victorialogs_tests --features victorialogs,external_integration integration_tests::test_victorialogs_sink_full_integration -- --exact --nocapture --ignored
 
 # VictoriaLogs sink 性能测试
-cargo test --package wp-connectors --test victorialogs_tests --features victorialogs,external_performance performance_tests::test_victorialogs_sink_performance -- --exact --nocapture --ignored
+cargo test --release --package wp-connectors --test victorialogs_tests --features victorialogs,external_performance performance_tests::test_victorialogs_sink_performance -- --exact --nocapture --ignored
 ```

--- a/tests/doris/common.rs
+++ b/tests/doris/common.rs
@@ -7,16 +7,35 @@ use sea_orm::{ConnectOptions as SeaConnectOptions, ConnectionTrait, Database};
 use serde_json::json;
 use std::str::FromStr;
 use wp_connector_api::ParamMap;
+use wp_model_core::model::{DataField, DataRecord};
 
+/// Doris BE HTTP 地址，用于 Stream Load 写入。
 pub const TEST_DORIS_ENDPOINT: &str = "http://localhost:8040";
+/// Doris MySQL 协议地址，用于建库建表、就绪探测和数量查询。
 pub const TEST_DORIS_MYSQL_HOST: &str = "127.0.0.1";
+/// Doris MySQL 协议端口。
 pub const TEST_DORIS_MYSQL_PORT: u16 = 9030;
+/// Doris 测试数据库名。
 pub const TEST_DORIS_DB: &str = "test_db";
+/// Doris 动态表名前缀，实际表名会拼成 `wp_nginx_<referer>`。
 pub const TEST_DORIS_TABLE: &str = "wp_nginx";
+/// Doris sink 动态表模板；测试记录中的 `referer` 字段会替换占位符。
+pub const TEST_DORIS_DYNAMIC_TABLE_TEMPLATE: &str = "wp_nginx_#{referer}";
+/// 集成测试预建的动态表数量，记录会按 `wp_event_id % 表数量` 路由。
+pub const INTEGRATION_DYNAMIC_TABLE_COUNT: i64 = 3;
+/// 性能测试预建的动态表数量，独立于性能测试总记录数。
+pub const PERFORMANCE_DYNAMIC_TABLE_COUNT: i64 = 1;
+/// 性能测试总记录数。
+pub const PERFORMANCE_RECORD_COUNT: usize = 1000_0000;
+/// Doris 测试用户名。
 pub const TEST_DORIS_USER: &str = "root";
+/// Doris 测试密码；None 表示空密码。
 pub const TEST_DORIS_PASSWORD: Option<&str> = None;
+/// Doris 就绪探测最大次数。
 const DORIS_READY_ATTEMPTS: usize = 30;
+/// Doris 就绪探测间隔秒数。
 const DORIS_READY_INTERVAL_SECS: u64 = 2;
+/// 连续探测成功次数，达到后才认为 Doris 集群稳定就绪。
 const DORIS_READY_STABLE_PROBES: usize = 3;
 
 pub fn doris_mysql_options(database: Option<&str>) -> Result<MySqlConnectOptions> {
@@ -82,7 +101,7 @@ pub fn create_doris_test_config() -> ParamMap {
     let mut params = ParamMap::new();
     params.insert("endpoint".into(), json!(TEST_DORIS_ENDPOINT));
     params.insert("database".into(), json!(TEST_DORIS_DB));
-    params.insert("table".into(), json!(TEST_DORIS_TABLE));
+    params.insert("table".into(), json!(TEST_DORIS_DYNAMIC_TABLE_TEMPLATE));
     params.insert("user".into(), json!(TEST_DORIS_USER));
     params.insert("password".into(), json!(TEST_DORIS_PASSWORD.unwrap_or("")));
     params.insert("timeout_secs".into(), json!(30));
@@ -90,17 +109,74 @@ pub fn create_doris_test_config() -> ParamMap {
     params
 }
 
+pub fn create_doris_test_record(id: i64, table_count: i64, prefix: &str) -> DataRecord {
+    let mut record = DataRecord::default();
+    record.append(DataField::from_digit("wp_event_id", id));
+    record.append(DataField::from_chars(
+        "wp_src_key",
+        format!("{prefix}_{id}"),
+    ));
+    record.append(DataField::from_chars("sip", "192.168.1.100"));
+    record.append(DataField::from_chars("timestamp", "2024-03-02 10:00:00"));
+    record.append(DataField::from_chars(
+        "http/request",
+        format!("GET /api/{prefix}/{id} HTTP/1.1"),
+    ));
+    record.append(DataField::from_digit("status", 200));
+    record.append(DataField::from_digit("size", 1024 + id));
+    record.append(DataField::from_chars(
+        "referer",
+        dynamic_table_suffix(id, table_count),
+    ));
+    record.append(DataField::from_chars(
+        "http/agent",
+        "Mozilla/5.0 (Doris Test)",
+    ));
+    record
+}
+
+pub fn create_doris_test_records(
+    start_id: i64,
+    count: usize,
+    table_count: i64,
+    prefix: &str,
+) -> Vec<DataRecord> {
+    (0..count)
+        .map(|idx| create_doris_test_record(start_id + idx as i64, table_count, prefix))
+        .collect()
+}
+
 pub async fn query_table_count() -> Result<i64> {
     let pool = create_doris_pool(Some(TEST_DORIS_DB)).await?;
-    let count = sqlx::query(&format!(
-        "SELECT COUNT(*) FROM {}.{}",
-        TEST_DORIS_DB, TEST_DORIS_TABLE
-    ))
-    .fetch_one(&pool)
-    .await?
-    .try_get::<i64, _>(0)?;
+    let count = query_dynamic_table_count(&pool).await?;
     pool.close().await;
     Ok(count)
+}
+
+pub async fn query_dynamic_table_count(pool: &sqlx::MySqlPool) -> Result<i64> {
+    let table_rows = sqlx::query(&format!(
+        "SHOW TABLES FROM {} LIKE '{}_%'",
+        quote_identifier(TEST_DORIS_DB),
+        TEST_DORIS_TABLE
+    ))
+    .fetch_all(pool)
+    .await?;
+
+    let mut total = 0i64;
+    for row in table_rows {
+        let table_name: String = row.try_get(0)?;
+        let count = sqlx::query(&format!(
+            "SELECT COUNT(*) FROM {}.{}",
+            quote_identifier(TEST_DORIS_DB),
+            quote_identifier(&table_name)
+        ))
+        .fetch_one(pool)
+        .await?
+        .try_get::<i64, _>(0)?;
+        total += count;
+    }
+
+    Ok(total)
 }
 
 fn read_bool_column(row: &MySqlRow, column: &str) -> Option<bool> {
@@ -239,7 +315,19 @@ pub async fn wait_for_doris_sink_ready() -> Result<()> {
 }
 
 pub async fn init_doris_database() -> Result<()> {
+    init_doris_database_with_suffixes(dynamic_table_suffixes(INTEGRATION_DYNAMIC_TABLE_COUNT)).await
+}
+
+pub async fn init_doris_performance_database() -> Result<()> {
+    init_doris_database_with_suffixes(dynamic_table_suffixes(PERFORMANCE_DYNAMIC_TABLE_COUNT)).await
+}
+
+pub async fn init_doris_database_with_suffixes<I>(suffixes: I) -> Result<()>
+where
+    I: IntoIterator<Item = String>,
+{
     println!("初始化 Doris 数据库和表...");
+    let suffixes: Vec<String> = suffixes.into_iter().collect();
 
     let db = create_doris_admin_conn(None).await?;
 
@@ -247,37 +335,21 @@ pub async fn init_doris_database() -> Result<()> {
         .await?;
     println!("✓ 数据库创建成功");
 
-    db.execute_unprepared(&format!(
-        "DROP TABLE IF EXISTS {}.{}",
-        TEST_DORIS_DB, TEST_DORIS_TABLE
-    ))
-    .await?;
-    println!("✓ 旧表已删除");
-
-    let create_table_sql = format!(
-        r#"CREATE TABLE {}.{} (
-            wp_event_id BIGINT COMMENT '事件唯一ID',
-            wp_src_key STRING COMMENT '数据来源表示',
-            sip STRING COMMENT '客户端IP',
-            `timestamp` STRING COMMENT '原始时间字符串',
-            `http/request` STRING COMMENT 'HTTP请求行',
-            status SMALLINT COMMENT 'HTTP状态码',
-            size INT COMMENT '响应大小(byte)',
-            referer STRING COMMENT '来源页面',
-            `http/agent` STRING COMMENT 'User-Agent'
-        )
-        ENGINE=OLAP
-        DUPLICATE KEY(wp_event_id)
-        DISTRIBUTED BY HASH(wp_event_id) BUCKETS 8
-        PROPERTIES ("replication_num" = "1")"#,
-        TEST_DORIS_DB, TEST_DORIS_TABLE
-    );
+    for table_name in list_existing_dynamic_tables().await? {
+        db.execute_unprepared(&format!(
+            "DROP TABLE IF EXISTS {}.{}",
+            quote_identifier(TEST_DORIS_DB),
+            quote_identifier(&table_name)
+        ))
+        .await?;
+    }
+    println!("✓ 旧动态表已删除");
 
     let mut last_error = None;
     for attempt in 1..=10 {
-        match db.execute_unprepared(&create_table_sql).await {
-            Ok(_) => {
-                println!("✓ 表创建成功");
+        match create_dynamic_tables(&db, &suffixes).await {
+            Ok(()) => {
+                println!("✓ 动态表创建成功");
                 return Ok(());
             }
             Err(err) => {
@@ -298,4 +370,70 @@ pub async fn init_doris_database() -> Result<()> {
         "表创建失败，已重试多次: {}",
         last_error.unwrap_or_else(|| "未知错误".to_string())
     )
+}
+
+async fn create_dynamic_tables(
+    db: &sea_orm::DatabaseConnection,
+    suffixes: &[String],
+) -> Result<()> {
+    for suffix in suffixes {
+        db.execute_unprepared(&create_table_sql(&format!(
+            "{}_{}",
+            TEST_DORIS_TABLE, suffix
+        )))
+        .await?;
+    }
+    Ok(())
+}
+
+async fn list_existing_dynamic_tables() -> Result<Vec<String>> {
+    let pool = create_doris_pool(Some(TEST_DORIS_DB)).await?;
+    let rows = sqlx::query(&format!(
+        "SHOW TABLES FROM {} LIKE '{}_%'",
+        quote_identifier(TEST_DORIS_DB),
+        TEST_DORIS_TABLE
+    ))
+    .fetch_all(&pool)
+    .await?;
+
+    let mut tables = Vec::with_capacity(rows.len());
+    for row in rows {
+        tables.push(row.try_get::<String, _>(0)?);
+    }
+    pool.close().await;
+    Ok(tables)
+}
+
+fn dynamic_table_suffix(id: i64, table_count: i64) -> String {
+    let bucket = id.rem_euclid(table_count);
+    format!("bucket_{bucket:04}")
+}
+
+fn dynamic_table_suffixes(table_count: i64) -> impl Iterator<Item = String> {
+    (0..table_count).map(move |id| dynamic_table_suffix(id, table_count))
+}
+
+fn create_table_sql(table_name: &str) -> String {
+    format!(
+        r#"CREATE TABLE {}.{} (
+            wp_event_id BIGINT COMMENT '事件唯一ID',
+            wp_src_key STRING COMMENT '数据来源表示',
+            sip STRING COMMENT '客户端IP',
+            `timestamp` STRING COMMENT '原始时间字符串',
+            `http/request` STRING COMMENT 'HTTP请求行',
+            status SMALLINT COMMENT 'HTTP状态码',
+            size INT COMMENT '响应大小(byte)',
+            `http/agent` STRING COMMENT 'User-Agent'
+        )
+        ENGINE=OLAP
+        DUPLICATE KEY(wp_event_id)
+        DISTRIBUTED BY HASH(wp_event_id) BUCKETS 8
+        PROPERTIES ("replication_num" = "1")"#,
+        quote_identifier(TEST_DORIS_DB),
+        quote_identifier(table_name)
+    )
+}
+
+fn quote_identifier(identifier: &str) -> String {
+    format!("`{}`", identifier.replace('`', "``"))
 }

--- a/tests/doris/sinks/integration_tests.rs
+++ b/tests/doris/sinks/integration_tests.rs
@@ -4,7 +4,8 @@
 use wp_connectors::doris::DorisSinkFactory;
 
 use crate::doris_common::{
-    create_doris_test_config, init_doris_database, query_table_count, wait_for_doris_sink_ready,
+    INTEGRATION_DYNAMIC_TABLE_COUNT, create_doris_test_config, create_doris_test_records,
+    init_doris_database, query_table_count, wait_for_doris_sink_ready,
 };
 use wp_connector_test_utils::{
     DockerComposeTool, RuntimeResult, SinkInfo, SinkIntegrationRuntime, ToolResultExt,
@@ -19,14 +20,21 @@ async fn test_doris_sink_full_integration() -> RuntimeResult<()> {
     let docker_tool =
         DockerComposeTool::new("tests/doris/component/integration_tests.yml").into_rt()?;
 
-    // 2. 创建 Sink 集成测试信息
+    // 使用框架的生命周期和重启验证，只覆盖测试记录生成逻辑。
     let sink_info = SinkInfo::new(DorisSinkFactory, create_doris_test_config())
-        .with_test_name("basic")
+        .with_test_name("dynamic_table")
         .with_async_count_fn(|_params| async { query_table_count().await })
         .with_async_wait_ready(|_params| async { wait_for_doris_sink_ready().await })
-        .with_async_init(|| async { init_doris_database().await });
+        .with_async_init(|| async { init_doris_database().await })
+        .with_record_builder(|start_id, count| {
+            create_doris_test_records(
+                start_id,
+                count,
+                INTEGRATION_DYNAMIC_TABLE_COUNT,
+                "integration_test",
+            )
+        });
 
-    // 3. 创建运行时并执行测试
     let runtime = SinkIntegrationRuntime::new(docker_tool, vec![sink_info]);
     runtime.run(true).await?;
 

--- a/tests/doris/sinks/performance_tests.rs
+++ b/tests/doris/sinks/performance_tests.rs
@@ -3,7 +3,9 @@
 use wp_connectors::doris::DorisSinkFactory;
 
 use crate::doris_common::{
-    create_doris_test_config, init_doris_database, query_table_count, wait_for_doris_sink_ready,
+    PERFORMANCE_DYNAMIC_TABLE_COUNT, PERFORMANCE_RECORD_COUNT, create_doris_test_config,
+    create_doris_test_records, init_doris_performance_database, query_table_count,
+    wait_for_doris_sink_ready,
 };
 use wp_connector_test_utils::{
     DockerComposeTool, RuntimeResult, SinkInfo, SinkPerformanceConfig, SinkPerformanceRuntime,
@@ -16,19 +18,25 @@ use wp_connector_test_utils::{
 async fn test_doris_sink_performance() -> RuntimeResult<()> {
     let docker_tool =
         DockerComposeTool::new("tests/doris/component/performance_tests.yml").into_rt()?;
-    // 添加sink信息、包括sink工厂、测试的初始化方法，基础方法
+
     let sink_info = SinkInfo::new(DorisSinkFactory, create_doris_test_config())
-        .with_test_name("baseline")
+        .with_test_name("dynamic_table")
         .with_async_count_fn(|_params| async { query_table_count().await })
-        .with_async_init(|| async { init_doris_database().await })
-        .with_async_wait_ready(|_params| async { wait_for_doris_sink_ready().await });
-    //性能测试配置
+        .with_async_init(|| async { init_doris_performance_database().await })
+        .with_async_wait_ready(|_params| async { wait_for_doris_sink_ready().await })
+        .with_record_builder(|start_id, count| {
+            create_doris_test_records(
+                start_id,
+                count,
+                PERFORMANCE_DYNAMIC_TABLE_COUNT,
+                "performance_test",
+            )
+        });
+
     let config = SinkPerformanceConfig::default()
-        .with_total_records(1000_0000)
-        //批量大小
-        .with_batch_size(1_0000)
-        //并行度
-        .with_task_count(4);
+        .with_total_records(PERFORMANCE_RECORD_COUNT)
+        .with_batch_size(10_000)
+        .with_task_count(8);
     let runtime = SinkPerformanceRuntime::new(docker_tool, vec![sink_info], config);
     runtime.run().await?;
     Ok(())


### PR DESCRIPTION
## 设计
用户在table字段中写入`xxx_#{字段名1}_xxx#{字段名2}`，在运行时会根据解析后的日志字段值替换掉`#{字段名}`部分，生成最终的表名。
### DorisSink 属性配置
- 原本url中的表名改为动态构建
- 添加一个数组`template_fields`，在初始化时，预先提取占位符字段，并存到该数组中。
- 提供一个结构体`DorisRecord`，其值有`table_name`:字符串,`values`:Vec<u8>
### 运行时表名构建
- 准备一个hashmap集合，key是拼接后的表名，values是DorisRecord
- 对于每一条数据，遍历其字段，如果字段在`template_fields`中，则用该字段值替换掉表名中的占位符，生成最终的表名`final_table_name`。
- 得到`final_table_name`后，从map集合中取出对应的DorisRecord，不存在则创建后加入map集合，将当前记录转换成json字节流后追加到DorisRecord的Vec<u8>中。

- 当所有记录处理完成后，遍历map集合，对每个表名和对应的字节流进行一次Stream Load请求。
- stream load方法需要做如下修改：
    - 添加一个`DorisRecord`参数
    - 删除`label`参数，label在stream load方法中内部生成。
    
 这套机制在单表情况下几乎无性能影响：
 在1000w数据下，性能依旧为50w eps
 
<img width="1610" height="1224" alt="image" src="https://github.com/user-attachments/assets/9bcb742c-7911-4f6a-8297-a935884849bf" />

在1000w数据、4张表的情况下略有下降，EPS为33w：
<img width="1746" height="756" alt="image" src="https://github.com/user-attachments/assets/ee4833d0-fc0f-4642-af04-d0a9fb49db06" />

